### PR TITLE
Feature/builds should be generic

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -4,7 +4,6 @@ param(
     [string]$Path = $PSScriptRoot,
     [string]$ModuleName = $(Split-Path $Path -Leaf),
     [switch]$Monitor,
-    [ValidateNotNullOrEmpty()]
     [Nullable[int]]$RevisionNumber = ${Env:APPVEYOR_BUILD_NUMBER}
 )
 

--- a/Get-Version.ps1
+++ b/Get-Version.ps1
@@ -1,0 +1,29 @@
+#.Synopsis
+# Calculate the build number.
+param(
+    $Module,
+    # If set, override the module's revision
+    [Nullable[int]]$RevisionNumber
+)
+
+[Version]$Version = if(Test-Path $Module -Type Leaf) {
+    (Import-LocalizedData -BaseDirectory (Split-Path $Module) -FileName (Split-Path ${Module} -Leaf)).ModuleVersion
+} elseif(Test-Path $Module -Type Container) {
+    (Import-LocalizedData -BaseDirectory $Module -FileName "$(Split-Path ${Module} -Leaf).psd1").ModuleVersion 
+} else {
+    Get-Module $Module -List | Select -First 1 -Expand Version 
+}
+
+if($RevisionNumber) {
+    # For release builds we don't increment the build number
+    $Build = if($Version.Build -le 0) { 0 } else { $Version.Build }
+} else {
+    # For dev builds, assume we're working on the NEXT release
+    $Build = if($Version.Build -le 0) { 1 } else { $Version.Build + 1}
+}
+
+if([string]::IsNullOrEmpty($RevisionNumber)) {
+    New-Object Version $Version.Major, $Version.Minor, $Build
+} else {
+    New-Object Version $Version.Major, $Version.Minor, $Build, $RevisionNumber
+}

--- a/Setup.ps1
+++ b/Setup.ps1
@@ -1,27 +1,33 @@
 #Requires -Version "4.0" -Module PackageManagement
-#NOTE: if you don't have PackageManagement, you can use nuget instead:
+#.Notes
+#      if you don't have PackageManagement, you can use nuget instead:
 #      nuget install libgit2sharp -OutputDirectory .\packages -ExcludeVersion
+[CmdletBinding()]
+param(
+    [Alias("PSPath")]
+    [string]$Path = $PSScriptRoot,
+    [string]$ModuleName = $(Split-Path $Path -Leaf)
+)
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
+Write-Host "SETUP $ModuleName in $Path"
 
-if(!(Test-Path Variable:global:LibGit2Sharp) -or !(Test-Path $global:LibGit2Sharp)) {
-    $global:LibGit2Sharp = Resolve-Path $PSScriptRoot\packages\libgit2sharp\lib\*\LibGit2Sharp.dll -ErrorAction SilentlyContinue
-}
-
-if(!$global:LibGit2Sharp) {
+if(Test-Path (Join-Path $Path packages.config)) {
     if(!($Name = Get-PackageSource | ? Location -eq 'https://www.nuget.org/api/v2' | % Name)) {
-       $Name = Register-PackageSource NuGet -Location 'https://www.nuget.org/api/v2' -ForceBootstrap -ProviderName NuGet | % Name
+        Write-Warning "Adding NuGet package source"
+        $Name = Register-PackageSource NuGet -Location 'https://www.nuget.org/api/v2' -ForceBootstrap -ProviderName NuGet | % Name
     }
-    $null = mkdir $PSScriptRoot\packages\ -Force
-    $package = Install-Package libgit2sharp -Source NuGet -Destination $PSScriptRoot\packages -ExcludeVersion -PackageSave nuspec -Force
+    $null = mkdir $Path\packages\ -Force
 
-    if(!$package) {
-        throw "Failed to install libgit2sharp assembly"
+    # This recreates nuget's package restore, but hypothetically, with support for any provider
+    # E.g.: nuget restore -PackagesDirectory "$Path\packages" -PackageSaveMode nuspec
+    foreach($Package in ([xml](gc .\packages.config)).packages.package) {
+        Write-Verbose "Installing $($Package.id) v$($Package.version) from $($Package.Source)"
+        $install = Install-Package -Name $Package.id -RequiredVersion $Package.version -Source $Package.Source -Destination $Path\packages -PackageSave nuspec -Force -ErrorVariable failure
+        if($failure) {
+            throw "Failed to install $($package.id), see errors above."
+        }
     }
-
-    $global:LibGit2Sharp = Resolve-Path $PSScriptRoot\packages\libgit2sharp\lib\*\LibGit2Sharp.dll -ErrorAction SilentlyContinue
 }
-
-Get-ChildItem $PSScriptRoot\packages\libgit2sharp\lib\*\*
 
 git submodule update --init --recursive

--- a/Test.ps1
+++ b/Test.ps1
@@ -28,6 +28,8 @@ $null = mkdir $OutputPath -Force
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version Latest
 
+Write-Verbose "Import-Module $PSScriptRoot\lib\Pester" -Verbose:(!$Quiet)
+Import-Module $PSScriptRoot\lib\Pester -Force
 if(!$SkipBuild) {
     &"$PSScriptRoot\Build.ps1" -Path:$Path -ModuleName:$ModuleName -RevisionNumber:$RevisionNumber
 }

--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+<package id="LibGit2Sharp" version="0.21.0.176" allowedVersions="[0.21,1.0)" source="https://www.nuget.org/api/v2" />
+</packages>


### PR DESCRIPTION
### Major Changes

Adds a packages.config so the setup and build scripts don't have to hardcode dependencies
Builds will now be produced with the "Build" number one higher than the released build (i.e. one higher than what's in the module's psd1 file).
#### Details

Adds a Get-Version script to read (and increment) the module version
Modifies Setup, Build, Test, Package to be as generic as possible, adds parameters
Modifies Test to call Build (because @jrich523 is annoyed that he keeps forgetting to build)

DOES NOT set the Appveyor Build version or anything.
