### PR TITLE
Use VisualStudio with PSTools as editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 /output/*
 # Ignore version number folders (these are our intermediate "output" directories for testing)
 /[0-9]*/
+# ignore PSTools for VisualStudio files and folders
+/bin/*
+/obj/*
+*.suo

--- a/PSGit.pssproj
+++ b/PSGit.pssproj
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>6CAFC0C6-A428-4d30-A9F9-700E829FEA51</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>MyApplication</RootNamespace>
+    <AssemblyName>MyApplication</AssemblyName>
+    <Name>PSGit</Name>
+    <Author>Test</Author>
+    <CompanyName />
+    <Copyright />
+    <Description />
+    <Guid>e7c5d328-f4c5-472f-969f-a32331cdc7c1</Guid>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Folder Include="src\" />
+    <Folder Include="test\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="appveyor.yml" />
+    <Compile Include="Build.ps1" />
+    <Compile Include="CONTRIBUTING.md" />
+    <Compile Include="Get-Version.ps1" />
+    <Compile Include="Package.ps1" />
+    <Compile Include="packages.config" />
+    <Compile Include="README.md" />
+    <Compile Include="Setup.ps1" />
+    <Compile Include="src\PSGit.psd1" />
+    <Compile Include="src\PSGit.psm1" />
+    <Compile Include="Test.ps1" />
+    <Compile Include="test\Changes.feature" />
+    <Compile Include="test\Info.feature" />
+    <Compile Include="test\Must.Steps.ps1" />
+    <Compile Include="test\Must.Tests.ps1" />
+    <Compile Include="test\NewRepository.feature" />
+    <Compile Include="test\Send-CodeCov.ps1" />
+    <Compile Include="test\Status.Steps.ps1" />
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Target Name="Build" />
+</Project>

--- a/PSGit.sln
+++ b/PSGit.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{F5034706-568F-408A-B7B3-4D38C6DB8A32}") = "PSGit", "PSGit.pssproj", "{6CAFC0C6-A428-4D30-A9F9-700E829FEA51}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6CAFC0C6-A428-4D30-A9F9-700E829FEA51}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6CAFC0C6-A428-4D30-A9F9-700E829FEA51}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6CAFC0C6-A428-4D30-A9F9-700E829FEA51}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6CAFC0C6-A428-4D30-A9F9-700E829FEA51}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Created a new VS PowerShellScriptModule project and manually added all PS-Git files.
Adapted .gitignore to ignore the bin and obj folders, as well as the .suo
